### PR TITLE
Redefine penalties

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -1,0 +1,64 @@
+#' get_parameter_labels
+#'
+#' @param model lavaan model
+#' @param leaf integer: number of the leaf
+#' @keywords internal
+get_parameter_labels <- function(model, leaf){
+
+  ### lessSEM can only regularize parameters that follow the naming convention
+  # of variables in C++. That is, the standard labels used by lavaan (e.g.,
+  # f=~y1) will not work. We could just change the labels, but this may be
+  # inconvenient for users who want to have control over which parameters should
+  # be regularized. The following approach is: check if the models has parameter
+  # labels given by the user. Check these labels for consistency with C++
+  # naming and then provide feedback that only those parameters with explicit
+  # labels can be regularized.
+
+  parameter_table <- model@ParTable
+  parameter_labels <- parameter_table$label
+
+  # If the user left some parameters unlabeled, we will take care of that here:
+
+  parameter_labels[parameter_labels == ""] <- paste0(
+    parameter_table$lhs[parameter_labels == ""],
+    parameter_table$op[parameter_labels == ""],
+    parameter_table$rhs[parameter_labels == ""])
+  # this will assign the standard lavaan labels to the previously unlabeled
+  # parameters
+
+  # Next, we will check which of these labels are valid in C++:
+  valid_labels <- sapply(parameter_labels, is_valid_name)
+
+  ## Make labels unique
+  parameter_table$label <- paste0(parameter_labels,
+                                  paste0("_leaf_", leaf))
+
+  # Finally, let's remove all fixed parameters:
+  parameter_labels <- parameter_labels[parameter_table$free != 0]
+  valid_labels <- valid_labels[parameter_table$free != 0]
+
+  return(list(
+    base_labels = parameter_labels, # labels prior to changing the names
+    parameter_table = parameter_table, # includes name changes
+    valid_labels = valid_labels # indicates if the name can be used in the
+    # regularization
+  ))
+
+}
+
+
+#' is_valid_name
+#'
+#' checks if a given variable name is valid in C++
+#' @param x name of the variable to be checked
+#' @return boolean
+#' @keywords internal
+is_valid_name <- function(x){
+
+  return(
+    # A valid name must start with a letter or underscore and continue
+    # with letters, underscores, or numbers.
+    grepl(pattern = "^[a-zA-Z_][a-zA-Z_0-9]*$",
+          x = x)
+  )
+}

--- a/R/regularize_semtree.R
+++ b/R/regularize_semtree.R
@@ -3,13 +3,11 @@
 #' Regularize SEM trees fitted with semtree. Requires tidyverse and lessSEM.
 #'
 #' @param tree A semtree object. Only SEM trees fitted with lavaan work.
-#' @param AIC blabla
+#' @param regularized optional: Select the parameters that should be regularized.
+#' If set to NULL, all parameters with user-defined names will be regularized.
 #' @return A list.
 #' @export
-
-regularize_semtree <- function(tree, penalty = "adaptiveLasso",
-                               lambdas = seq(0, 0.25,length.out = 50),
-                               criterion = "AIC") {
+regularize_semtree <- function(tree, regularized = NULL) {
 
   # Extracting the models and their parameters ----
 
@@ -17,6 +15,7 @@ regularize_semtree <- function(tree, penalty = "adaptiveLasso",
   n_leafs <- length(leafs)
 
   base_parameters <- c()
+  is_valid_parameter <- c()
   parameters <- c()
   models <- c()
 
@@ -24,41 +23,65 @@ regularize_semtree <- function(tree, penalty = "adaptiveLasso",
 
     model <- leafs[[leaf]]$model
 
-    base_parameters <- c(base_parameters, names(getLavaanParameters(model)))
+    model_parameters <- get_parameter_labels(model = model,
+                                             leaf = leaf)
 
-    parameter_table <- model@ParTable
+    base_parameters <- c(base_parameters,
+                         unique(model_parameters$base_labels))
 
-    # we have to give labels to those parameters that currently don't have names:
-    parameter_labels <- parameter_table$label
-    parameter_table$label[parameter_labels == ""] <- paste0(
-      parameter_table$lhs[parameter_labels == ""],
-      parameter_table$op[parameter_labels == ""],
-      parameter_table$rhs[parameter_labels == ""])
-
-    parameter_table$label <- paste0(parameter_table$label, "_leaf_", leaf)
+    is_valid_parameter <- c(is_valid_parameter,
+                            model_parameters$valid_labels[unique(model_parameters$base_labels)]
+    )
 
     models <- c(models,
-                lavaan(model = parameter_table,
+                lavaan(model = model_parameters$parameter_table,
                        data = lavInspect(object = model, what = "data"))
     )
 
+    # get final parameter names for this model:
     parameters <- c(parameters,
                     names(getLavaanParameters(models[[leaf]])))
 
   }
 
+  ## Provide some feedback to the user:
+  cat("\n")
+  cat("Setting up lessTREE. The following parameters will be regularized: ")
+  cat(paste0(unique(base_parameters[is_valid_parameter]), collapse = ", "))
+  cat("\n")
+
+  if(any(!is_valid_parameter)){
+    cat(crayon::blue("The following parameters will be estimated group-specific,",
+                     "but cannot be regularized because their",
+                     "names are inconsistent with the naming convention used in lessSEM: "))
+    cat(crayon::blue(paste0(unique(base_parameters[!is_valid_parameter]), collapse = ", ")))
+    cat(crayon::blue("\nAll names must start with letters and special characters (e.g., ",
+                     "~, -, or >) are not allowed."))
+  }
 
   # Defining the transformations ----
 
   delta_parameters <- paste0("delta_", parameters)
 
+  # check if only a subset of the parameters should be regularized
+  if(!is.null(regularized)){
+    regularize <- base_parameters %in% regularized
+  }else{
+    regularize <- rep(TRUE, length(base_parameters))
+  }
+
   transformation <- paste0(
     "parameters: ",
-    paste0(unique(c(base_parameters, delta_parameters, parameters)),
+    paste0(unique(c(base_parameters[is_valid_parameter & regularize],
+                    delta_parameters[is_valid_parameter & regularize],
+                    parameters[is_valid_parameter & regularize])),
            collapse = ", "),
     "\n\n")
 
   for(i in 1:length(delta_parameters)){
+    # skip parameters with invalid names:
+    if(!is_valid_parameter[i] | !regularize[i])
+      next
     transformation <- paste0(
       transformation,
       paste0(parameters[i], " = ", base_parameters[i], " + ", delta_parameters[i],
@@ -66,51 +89,174 @@ regularize_semtree <- function(tree, penalty = "adaptiveLasso",
       "\n")
   }
 
+  # return new object which can then be regularized:
+  base_tree <- list(
+    lavaanModel = models,
+    modifyModel = modifyModel(transformations = transformation),
+    regularized = delta_parameters[is_valid_parameter & regularize],
+    # only those base parameters for regularized parameters; we don't really care about the rest
+    base_parameters = unique(base_parameters[is_valid_parameter & regularize]),
+    n_leafs = n_leafs,
+    fit = NULL # we will save the fitted lessSEM here
+  )
 
-  # Choose penalty ----
+  class(base_tree) <- "lessTREE"
 
-  if (penalty == "adaptiveLasso") {
+  return(base_tree)
 
-    ridge_start <- models |>
-      ridge(regularized = delta_parameters,
+}
+
+
+#' tree_ridge
+#'
+#' regularize tree with ridge penalty
+#'
+#' @param base_tree object returned by the regularize_tree()-function
+#' @param lambdas	numeric vector: values for the tuning parameter lambda
+#' @param method which optimizer should be used? Currently implemented are ista
+#' and glmnet. With ista, the control argument can be used to switch to related
+#' procedures (currently gist).
+#' @param control	used to control the optimizer. This element is generated with
+#' the controlIsta and controlGlmnet functions. See ?controlIsta and ?controlGlmnet for more details.
+#' @return regularized SEM-tree
+#' @export
+tree_ridge <- function(base_tree,
+                       lambdas,
+                       method = "glmnet",
+                       control = controlGlmnet()){
+
+  base_tree$fit <- suppressMessages(lessSEM::ridge(lavaanModel = base_tree$lavaanModel,
+                                                   regularized = base_tree$regularized,
+                                                   lambdas = lambdas,
+                                                   modifyModel = base_tree$modifyModel,
+                                                   control = control))
+
+  return(base_tree)
+}
+
+#' tree_lasso
+#'
+#' regularize tree with ridge penalty
+#'
+#' @param base_tree object returned by the regularize_tree()-function
+#' @param lambdas	numeric vector: values for the tuning parameter lambda
+#' @param method which optimizer should be used? Currently implemented are ista
+#' and glmnet. With ista, the control argument can be used to switch to related
+#' procedures (currently gist).
+#' @param control	used to control the optimizer. This element is generated with
+#' the controlIsta and controlGlmnet functions. See ?controlIsta and ?controlGlmnet for more details.
+#' @return regularized SEM-tree
+#' @export
+tree_lasso <- function(base_tree,
+                       lambdas,
+                       method = "glmnet",
+                       control = controlGlmnet()){
+  base_tree$fit <- suppressMessages(lessSEM::lasso(lavaanModel = base_tree$lavaanModel,
+                                                   regularized = base_tree$regularized,
+                                                   lambdas = lambdas,
+                                                   method = method,
+                                                   control = control,
+                                                   modifyModel = base_tree$modifyModel))
+  return(base_tree)
+}
+
+#' tree_adaptive_lasso
+#'
+#' regularize tree with ridge penalty
+#'
+#' @param base_tree object returned by the regularize_tree()-function
+#' @param lambdas	numeric vector: values for the tuning parameter lambda
+#' @param weights weights used by the adaptive lasso. If set to NULL, lessTREE will
+#' construct weights based on a ridge regularized model.
+#' @param method which optimizer should be used? Currently implemented are ista
+#' and glmnet. With ista, the control argument can be used to switch to related
+#' procedures (currently gist).
+#' @param control	used to control the optimizer. This element is generated with
+#' the controlIsta and controlGlmnet functions. See ?controlIsta and ?controlGlmnet for more details.
+#' @return regularized SEM-tree
+#' @export
+tree_adaptive_lasso <- function(base_tree,
+                                lambdas,
+                                weights = NULL,
+                                method = "glmnet",
+                                control = controlGlmnet()){
+
+  if(is.null(weights)){
+    # we can find some approximate weights using a ridge penalty
+    ridge_start <- base_tree$lavaanModel |>
+      ridge(regularized = base_tree$regularized,
             lambdas = .01,
-            modifyModel = modifyModel(transformations = transformation))
+            modifyModel = base_tree$modifyModel)
 
     start <- coef(ridge_start)@estimates[1,]
 
     # Define adaptive lasso weights:
     weights <- 1/abs(start)
-
-  lasso_fit <- models |>
-    adaptiveLasso(regularized = delta_parameters,
-                  lambdas = lambdas,
-                  weights = weights,
-                  modifyModel = modifyModel(transformations = transformation))
   }
 
-  if (penalty == "lasso") {
+  base_tree$fit <- suppressMessages(lessSEM::adaptiveLasso(lavaanModel = base_tree$lavaanModel,
+                                                           regularized = base_tree$regularized,
+                                                           lambdas = lambdas,
+                                                           weights = weights,
+                                                           modifyModel = base_tree$modifyModel))
 
-    lasso_fit <- models |>
-      lasso(regularized = delta_parameters,
-                    lambdas = lambdas,
-                    modifyModel = modifyModel(transformations = transformation))
-  }
+  return(base_tree)
+}
 
-  # Extract final parameter values using the AIC
-  min_at <- which.min(AIC(lasso_fit)$AIC)
-  df_coef <- as.data.frame(lasso_fit@parameters[min_at,])
+#' tree_mixed_penalty
+#'
+#' regularize tree with mixed penalty. See ?lessSEM::mixedPenalty for more details.
+#'
+#' @param base_tree object returned by the regularize_tree()-function
+#' @param control	used to control the optimizer. This element is generated with
+#' the controlIsta and controlGlmnet functions. See ?controlIsta and ?controlGlmnet for more details.
+#' @return regularized SEM-tree
+#' @export
+tree_mixed_penalty <- function(base_tree,
+                               control = controlIsta()){
+  return(
+    lessSEM::mixedPenalty(lavaanModel = base_tree$lavaanModel,
+                          modifyModel = base_tree$modifyModel,
+                          control = control)
+  )
+}
 
+#' print.lessTREE
+#'
+#' really lazy print for lessTREE...
+#' @param x object of class lessTREE
+#' @param ... nothing, to be honest
+#' @return nothing
+#' @export
+print.lessTREE <- function(x, ...){
+  cat("\nNothing to see here.\n")
+}
+
+#' select_final
+#'
+#' select and return the final parameters from a lessTREE object
+#' @param lessTREE object of class lessTREE
+#' @param criterion AIC or BIC
+#' @return list with summaries
+#' @export
+select_final <- function(lessTREE, criterion){
+
+  # Extract final parameter values using the AIC or BIC
+  if(criterion == "AIC")
+    min_at <- which.min(AIC(lessTREE$fit)$AIC)
+  if(criterion == "BIC")
+    min_at <- which.min(BIC(lessTREE$fit)$BIC)
+
+  df_coef <- as.data.frame(lessTREE$fit@parameters[min_at,])
 
   # Make output ----
 
-  parameter_labels <- unique(parameter_labels)
-  parameter_labels <- parameter_labels[!parameter_labels == ""]
+  parameter_average <- df_coef[c("lambda", "alpha", lessTREE$base_parameters)]
 
-  parameter_average <- df_coef[c("lambda", "alpha", parameter_labels)]
-
-  df_delta <- df_coef |> pivot_longer(cols = contains("leaf"),
-                                      names_to = "par_leaf",
-                                      values_to = "delta") |>
+  df_delta <- df_coef |>
+    pivot_longer(cols = contains("leaf"),
+                 names_to = "par_leaf",
+                 values_to = "delta") |>
     select(par_leaf, delta) |>
     mutate(parameter = str_replace(par_leaf, pattern = "delta_",
                                    replacement = "")) |>
@@ -121,12 +267,12 @@ regularize_semtree <- function(tree, penalty = "adaptiveLasso",
     mutate(leaf = parse_number(par_leaf)) |>
     select(leaf, parameter, delta)
 
-  list(n_par = length(parameter_labels),
-       n_leafs = n_leafs,
+  list(n_par = BIC(lessTREE$fit)$nonZeroParameters[min_at],
+       n_leafs = lessTREE$n_leafs,
        lambda = df_coef["lambda"],
        alpha = df_coef["alpha"],
        parameter_average = parameter_average,
        delta = as.data.frame(df_delta),
-       internal = lasso_fit)
+       internal = lessTREE)
 
 }

--- a/R/regularize_semtree.R
+++ b/R/regularize_semtree.R
@@ -51,12 +51,13 @@ regularize_semtree <- function(tree, regularized = NULL) {
   cat("\n")
 
   if(any(!is_valid_parameter)){
-    cat(crayon::blue("The following parameters will be estimated group-specific,",
+    cat(crayon::red("✖ "),
+        "The following parameters will be estimated group-specific,",
                      "but cannot be regularized because their",
-                     "names are inconsistent with the naming convention used in lessSEM: "))
-    cat(crayon::blue(paste0(unique(base_parameters[!is_valid_parameter]), collapse = ", ")))
-    cat(crayon::blue("\nAll names must start with letters and special characters (e.g., ",
-                     "~, -, or >) are not allowed."))
+                     "names are inconsistent with the naming convention used in lessSEM: ")
+    cat(crayon::red(paste0(unique(base_parameters[!is_valid_parameter]), collapse = ", ")))
+    cat("\nAll names must start with letters and special characters (e.g., ",
+                     "~, -, or >) are not allowed. Consider changing the names of these parameters.\n")
   }
 
   # Defining the transformations ----

--- a/tests/testthat/test-HolzingerSwineford.R
+++ b/tests/testthat/test-HolzingerSwineford.R
@@ -26,10 +26,13 @@ x9 ~~ d9*x9
 
   ctrl_tree <- semtree.control(method = "score", min.bucket = 10)
 
-  tree <- semtree(model = fit, data = HolzingerSwineford1939[complete.cases(HolzingerSwineford1939),],
+  tree <- semtree(model = fit,
+                  data = HolzingerSwineford1939[complete.cases(HolzingerSwineford1939),],
                   control = ctrl_tree,
                   predictors = c("sex", "school"))
 
-  rtree <- regularize_semtree(tree = tree)
+  rtree <- regularize_semtree(tree = tree) |>
+    tree_lasso(lambdas = seq(0.1,1,.1))
 
+  out <- select_final(rtree, criterion = "BIC")
 })

--- a/tests/testthat/test-HolzingerSwineford.R
+++ b/tests/testthat/test-HolzingerSwineford.R
@@ -35,4 +35,38 @@ x9 ~~ d9*x9
     tree_lasso(lambdas = seq(0.1,1,.1))
 
   out <- select_final(rtree, criterion = "BIC")
-})
+
+  # let's test a model, where some parameters have names that are not
+  # allowed:
+  ## The famous Holzinger and Swineford (1939) example
+  HS.model <- ' visual  =~ 1*x1 + l21*x2 + l31*x3
+              textual =~ 1*x4 + l52*x5 + l62*x6
+              speed   =~ 1*x7 + l83*x8 + l93*x9
+              visual ~~ v1*visual + v12*textual + speed
+textual ~~ v2*textual + v23*speed
+speed ~~ v3*speed
+x1 ~~ x1
+x2 ~~ x2
+x3 ~~ d3*x3
+x4 ~~ d4*x4
+x5 ~~ d5*x5
+x6 ~~ d6*x6
+x7 ~~ d7*x7
+x8 ~~ x8
+x9 ~~ d9*x9
+'
+  fit <- cfa(HS.model, data = HolzingerSwineford1939[complete.cases(HolzingerSwineford1939),])
+
+  ctrl_tree <- semtree.control(method = "score", min.bucket = 10)
+
+  tree <- semtree(model = fit,
+                  data = HolzingerSwineford1939[complete.cases(HolzingerSwineford1939),],
+                  control = ctrl_tree,
+                  predictors = c("sex", "school"))
+
+  rtree <- regularize_semtree(tree = tree) |>
+    tree_lasso(lambdas = seq(0.1,1,.1))
+
+  out <- select_final(rtree, criterion = "BIC")
+
+  })


### PR DESCRIPTION
I've changed the implementation of some penalties to make the interface more flexible. We can also consider making it simpler again, but I would like to have separate functions for lasso, adaptive lasso, ridge, etc. I think it is confusing if we are using the same function for all penalties. The current two-step approach allows advanced users to redefine elements of the regularized object prior to actually estimating it. 